### PR TITLE
fix: 修复竖图在双主题及编辑器中不居中、过度拉长的问题

### DIFF
--- a/src/features/posts/editor/extensions/images/block.tsx
+++ b/src/features/posts/editor/extensions/images/block.tsx
@@ -11,6 +11,11 @@ export function ImageBlock({
 }: NodeViewProps) {
   const src = node.attrs.src;
   const isUploading = useMemo(() => src?.startsWith("blob:"), [src]);
+  const isPortrait = !!(
+    node.attrs.width &&
+    node.attrs.height &&
+    node.attrs.height > node.attrs.width
+  );
 
   return (
     <NodeViewWrapper className="my-12 relative image-node-view">
@@ -25,10 +30,14 @@ export function ImageBlock({
         `}
       >
         <div
-          className="relative bg-muted/20 overflow-hidden"
+          className={`relative bg-muted/20 overflow-hidden ${
+            isPortrait
+              ? "flex items-center justify-center max-h-[70vh]"
+              : "max-h-[80vh]"
+          }`}
           style={{
             aspectRatio:
-              node.attrs.width && node.attrs.height
+              !isPortrait && node.attrs.width && node.attrs.height
                 ? `${node.attrs.width} / ${node.attrs.height}`
                 : "auto",
           }}
@@ -36,7 +45,11 @@ export function ImageBlock({
           <img
             src={src}
             alt={node.attrs.alt}
-            className={`w-full h-auto max-h-[80vh] object-contain mx-auto transition-opacity duration-300 ${
+            className={`${
+              isPortrait
+                ? "h-auto w-auto max-h-[70vh] max-w-full mx-auto block"
+                : "w-full h-auto max-h-[80vh] object-contain mx-auto"
+            } transition-opacity duration-300 ${
               isUploading ? "opacity-50 grayscale" : "opacity-100"
             }`}
           />

--- a/src/features/theme/themes/default/components/content/zoomable-image.tsx
+++ b/src/features/theme/themes/default/components/content/zoomable-image.tsx
@@ -147,17 +147,23 @@ export default function ZoomableImage({
     }
   }, []);
 
+  const isPortrait = !!(width && height && height > width);
+
   if (!src) return null;
 
   return (
     <>
       <div
         className={cn(
-          "relative group cursor-zoom-in block w-full overflow-hidden bg-muted/20",
+          "relative group cursor-zoom-in block overflow-hidden bg-muted/20",
+          isPortrait
+            ? "flex items-center justify-center w-full max-h-[70vh]"
+            : "w-full max-h-[80vh]",
           !isLoaded && "animate-pulse",
         )}
         style={{
-          aspectRatio: width && height ? `${width} / ${height}` : "auto",
+          aspectRatio:
+            !isPortrait && width && height ? `${width} / ${height}` : "auto",
         }}
         onClick={() => setIsOpen(true)}
       >
@@ -171,7 +177,8 @@ export default function ZoomableImage({
           onError={() => setIsLoaded(true)}
           className={cn(
             className,
-            "block transition-all duration-500",
+            "transition-all duration-500",
+            isPortrait && "h-auto w-auto max-h-[70vh] max-w-full mx-auto block",
             isLoaded ? "opacity-100" : "opacity-0",
           )}
           {...props}

--- a/src/features/theme/themes/fuwari/components/content/zoomable-image.tsx
+++ b/src/features/theme/themes/fuwari/components/content/zoomable-image.tsx
@@ -182,6 +182,8 @@ export default function ZoomableImage({
   const [thumbRect, setThumbRect] = useState<DOMRect | null>(null);
   const imgRef = useRef<HTMLImageElement>(null);
 
+  const isPortrait = !!(width && height && height > width);
+
   if (!src) return null;
 
   const handleOpen = () => {
@@ -194,7 +196,11 @@ export default function ZoomableImage({
   return (
     <>
       <div
-        className="w-full h-auto cursor-zoom-in group select-none overflow-hidden m-0 p-0 rounded-xl"
+        className={`cursor-zoom-in group select-none overflow-hidden m-0 p-0 rounded-xl ${
+          isPortrait
+            ? "flex items-center justify-center w-full max-h-[70vh]"
+            : "w-full h-auto"
+        }`}
         onClick={handleOpen}
       >
         <img
@@ -205,8 +211,11 @@ export default function ZoomableImage({
           height={height}
           loading="lazy"
           className={cn(
-            "w-full h-auto block transition-all duration-500 will-change-transform m-0 p-0",
             className,
+            "transition-all duration-500 will-change-transform m-0 p-0",
+            isPortrait
+              ? "h-auto w-auto max-h-[70vh] max-w-full mx-auto block"
+              : "w-full h-auto block max-h-[80vh] object-contain",
           )}
           {...props}
         />


### PR DESCRIPTION
fix: 修复竖图在双主题及编辑器中不居中、过度拉长的问题

竖图（height > width）在 wrapper 上设置 aspect-ratio 会导致容器过高，被 max-h 截断后变成宽扁矩形，图片在内无法居中。修复方案：

- 竖图不设 aspect-ratio，容器高度由图片内容自然决定
- 竖图 img 使用 h-auto w-auto max-h-[70vh] max-w-full mx-auto block 居中
- 横图保持原有 aspect-ratio + object-cover/object-contain 行为不变
- 内部尺寸 class 放在 cn() 末尾，确保覆盖父组件传入的 w-full 等规则

涉及文件：
- default/zoomable-image.tsx
- fuwari/zoomable-image.tsx
- editor/extensions/images/block.tsx @

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* **图片布局优化**
  * 图片显示现已根据宽高比自动调整：竖向图片采用居中紧凑展示并应用更严格的高度限制；横向图片保持全宽展示策略。改进适用于编辑器和主题中的图片渲染效果。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/du2333/flare-stack-blog/pull/104)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->