### PR TITLE
feat: Obsidian sync API for publishing Markdown notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
           echo "VITE_TURNSTILE_SITE_KEY=${{ vars.VITE_TURNSTILE_SITE_KEY }}" >> $GITHUB_ENV
           echo "THEME=${{ vars.THEME }}" >> $GITHUB_ENV
           echo "TURNSTILE_SECRET_KEY=${{ secrets.TURNSTILE_SECRET_KEY }}" >> $GITHUB_ENV
+          echo "OBSIDIAN_SYNC_TOKEN=${{ secrets.OBSIDIAN_SYNC_TOKEN }}" >> $GITHUB_ENV
 
       - name: Inject Resource IDs
         run: |
@@ -114,7 +115,8 @@ jobs:
             "UMAMI_SRC": "$UMAMI_SRC",
             "PAGEVIEW_SALT": "$PAGEVIEW_SALT",
             "TURNSTILE_SECRET_KEY": "$TURNSTILE_SECRET_KEY",
-            "GITHUB_TOKEN": "$GITHUB_TOKEN"
+            "GITHUB_TOKEN": "$GITHUB_TOKEN",
+            "OBSIDIAN_SYNC_TOKEN": "$OBSIDIAN_SYNC_TOKEN"
           }
           EOF
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Flare Stack Blog 的所有面向用户的页面与布局均通过 **主题契约
 | `TURNSTILE_SECRET_KEY`    | 运行时 | Cloudflare Turnstile 人机验证 Secret Key                                                                  |
 | `VITE_TURNSTILE_SITE_KEY` | 构建时 | Cloudflare Turnstile Site Key                                                                             |
 | `GITHUB_TOKEN`            | 运行时 | GitHub API Token（版本更新检查，避免限流）                                                                |
+| `OBSIDIAN_SYNC_TOKEN`     | Secret | Obsidian 同步 API 的 Bearer Token                                                                        |
 | `LOCALE`                  | 运行时 | 默认语言，支持 `zh` / `en`，默认 `zh`；通知邮件、Webhook 文本和后台异步任务文案会使用该语言               |
 | `CDN_DOMAIN`              | 运行时 | 独立 CDN 域名（如 `cdn.example.com`），purge 时优先使用；须为当前 Zone 下通过 SaaS CNAME 接入的自定义域名 |
 | `ROUTE`                   | CI/CD  | 设为 `1` 时，GitHub Actions 部署自动改用 Cloudflare `routes` 模式                                        |

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -206,6 +206,7 @@ Please refer to the **[Flare Stack Blog Deployment Guide](./deployment-guide.en.
 | `TURNSTILE_SECRET_KEY`    | Runtime    | Cloudflare Turnstile Secret Key for CAPTCHA.                                                             |
 | `VITE_TURNSTILE_SITE_KEY` | Build-time | Cloudflare Turnstile Site Key.                                                                           |
 | `GITHUB_TOKEN`            | Runtime    | GitHub API Token (for version updates checking to avoid rate limits).                                    |
+| `OBSIDIAN_SYNC_TOKEN`     | Secret     | Bearer token for the Obsidian synchronization API.                                                       |
 | `LOCALE`                  | Runtime    | Default language: `zh` or `en`. Default: `zh`. Used for emails, webhooks, and background task messaging. |
 | `CDN_DOMAIN`              | Runtime    | Standalone CDN domain (e.g., `cdn.example.com`), preferentially used during purge.                       |
 | `PAGEVIEW_SALT`           | Runtime    | Salt for anonymizing pageview visitor hashes. Generate with `openssl rand -hex 16`.                      |

--- a/docs/plans/2026-09-10-obsidian-blog-sync-design.md
+++ b/docs/plans/2026-09-10-obsidian-blog-sync-design.md
@@ -1,0 +1,26 @@
+# Obsidian Blog Sync Integration Design
+
+## Goal
+
+让 Obsidian 插件通过博客自身的 `/api/obsidian/articles` 接口创建、读取、更新和删除博客 Post，并在修改后复用博客现有的发布处理工作流。
+
+## Architecture
+
+博客端新增独立的同步 feature：Bearer Token 鉴权、请求校验、`obsidian_post_links` 链接表和 Hono 路由。正文仍唯一存放在 `posts.contentJson`；链接表保存 Obsidian 路径、同步 revision 和内容 hash。条件更新在链接表 revision/hash 仍匹配时才写入 Post，随后触发 `POST_PROCESS_WORKFLOW`。
+
+插件继续使用现有 TipTap JSON 协议、frontmatter 元数据和冲突处理；生产 API URL 配置为博客域名。API 返回博客域名生成的 Post URL 和可选的 Obsidian URI。
+
+## Data flow
+
+1. `POST` 校验标题、slug、TipTap JSON 和发布状态，创建 Post 与链接记录。
+2. `GET` 按 Post ID 游标分页，返回草稿和已发布 Post。
+3. `PUT` 检查 revision/hash；不匹配返回 409 当前 Post，不修改数据；匹配时更新 Post、链接记录并触发处理工作流。
+4. `DELETE` 显式删除 Post，链接记录由外键级联删除。
+
+## Security and consistency
+
+接口只接受 `Authorization: Bearer <OBSIDIAN_SYNC_TOKEN>`。Token 存在 Cloudflare Secret，不进入仓库。接口响应使用 `Cache-Control: no-store`，避免同步数据被公共缓存。revision/hash 写入链接表而不是依赖 Post 的 `updatedAt`，保证网站后台编辑也能被检测为冲突。
+
+## Verification
+
+集成测试覆盖鉴权、创建、列表/读取、条件更新、409 冲突、强制更新、删除和工作流触发；随后运行博客端 typecheck/test 以及插件端 test/build/lint。

--- a/docs/plans/2026-09-10-obsidian-blog-sync-implementation.md
+++ b/docs/plans/2026-09-10-obsidian-blog-sync-implementation.md
@@ -1,0 +1,59 @@
+# Obsidian Blog Sync Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a production Obsidian synchronization API to the blog Worker backed by existing Posts and post processing workflows.
+
+**Architecture:** Add an `obsidian_post_links` Drizzle table and a focused sync feature with token authentication, validation, repository operations, and Hono routes. Keep TipTap JSON in `posts.contentJson`, use link-table revision/hash for optimistic concurrency, and enqueue `POST_PROCESS_WORKFLOW` after content/status changes.
+
+**Tech Stack:** TypeScript, Hono, Drizzle D1, Zod, Cloudflare Workflows, Vitest.
+
+---
+
+### Task 1: Add failing sync contract tests
+
+**Files:**
+- Create: `src/features/obsidian-sync/obsidian-sync.integration.test.ts`
+
+**Steps:**
+1. Test missing/invalid bearer tokens, create, list, get, conditional update, stale conflict, force update, and explicit delete.
+2. Test that create/update schedule the existing post process workflow and that responses use the configured domain.
+3. Run `bun vitest run src/features/obsidian-sync/obsidian-sync.integration.test.ts`; confirm route/module failures.
+
+### Task 2: Add link-table schema and migration
+
+**Files:**
+- Create: `src/lib/db/schema/obsidian-post-links.table.ts`
+- Modify: `src/lib/db/schema/index.ts`
+- Create: `migrations/0011_*.sql`
+- Update: `migrations/meta/_journal.json` and generated snapshot through Drizzle
+
+**Steps:**
+1. Define Post foreign key, path, revision, hash, and timestamps.
+2. Add migration and verify fresh/local D1 migration state.
+
+### Task 3: Implement sync service and route
+
+**Files:**
+- Create: `src/features/obsidian-sync/schema/obsidian-sync.schema.ts`
+- Create: `src/features/obsidian-sync/data/obsidian-sync.data.ts`
+- Create: `src/features/obsidian-sync/service/obsidian-sync.service.ts`
+- Create: `src/features/obsidian-sync/api/hono/obsidian-sync.route.ts`
+- Modify: `src/lib/hono/routes.ts`, `src/lib/env/server.env.ts`, `global.d.ts`, `wrangler.example.jsonc`
+
+**Steps:**
+1. Add request schemas and stable SHA-256 hashing of title plus TipTap content.
+2. Implement authenticated create/list/get/update/delete operations using PostRepo/PostService and link rows.
+3. Trigger `POST_PROCESS_WORKFLOW` for create/update status changes; return structured errors and no-store headers.
+4. Mount the route before public cache/shield handling.
+
+### Task 4: Verify and update plugin contract
+
+**Files:**
+- Modify: `J:/Project/brige-obsidian-with-flarestackblog/brige-obsidian-with-flarestackblog/docs/api/blogweb-adapter.md`
+- Modify: `J:/Project/brige-obsidian-with-flarestackblog/brige-obsidian-with-flarestackblog/docs/使用教程.md`
+
+**Steps:**
+1. Document the production endpoint and `OBSIDIAN_SYNC_TOKEN` secret.
+2. Run blog `bun typecheck`, focused integration tests, and full test suite.
+3. Run plugin `npm test`, `npm run build`, and `npm run lint`.

--- a/global.d.ts
+++ b/global.d.ts
@@ -44,6 +44,7 @@ declare global {
   }
 
   interface Env extends Cloudflare.Env {
+    OBSIDIAN_SYNC_TOKEN?: string;
     POST_PROCESS_WORKFLOW: Workflow<PostProcessWorkflowParams>;
     POST_AUTO_SNAPSHOT_WORKFLOW: Workflow<PostAutoSnapshotWorkflowParams>;
     COMMENT_MODERATION_WORKFLOW: Workflow<CommentModerationWorkflowParams>;

--- a/migrations/0011_obsidian_post_links.sql
+++ b/migrations/0011_obsidian_post_links.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `obsidian_post_links` (
+	`post_id` integer PRIMARY KEY NOT NULL,
+	`obsidian_path` text,
+	`revision` integer DEFAULT 1 NOT NULL,
+	`content_hash` text NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/migrations/meta/0011_snapshot.json
+++ b/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1501 @@
+{
+    "version":  "7",
+    "dialect":  "sqlite",
+    "id":  "9b5e0f5d-e32a-4fe6-a3dd-d04768470bfa",
+    "prevId":  "95aaafc8-43c4-47a9-a47a-96929607b0be",
+    "tables":  {
+                   "account":  {
+                                   "name":  "account",
+                                   "columns":  {
+                                                   "id":  {
+                                                              "name":  "id",
+                                                              "type":  "text",
+                                                              "primaryKey":  true,
+                                                              "notNull":  true,
+                                                              "autoincrement":  false
+                                                          },
+                                                   "account_id":  {
+                                                                      "name":  "account_id",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                   "provider_id":  {
+                                                                       "name":  "provider_id",
+                                                                       "type":  "text",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false
+                                                                   },
+                                                   "user_id":  {
+                                                                   "name":  "user_id",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false
+                                                               },
+                                                   "access_token":  {
+                                                                        "name":  "access_token",
+                                                                        "type":  "text",
+                                                                        "primaryKey":  false,
+                                                                        "notNull":  false,
+                                                                        "autoincrement":  false
+                                                                    },
+                                                   "refresh_token":  {
+                                                                         "name":  "refresh_token",
+                                                                         "type":  "text",
+                                                                         "primaryKey":  false,
+                                                                         "notNull":  false,
+                                                                         "autoincrement":  false
+                                                                     },
+                                                   "id_token":  {
+                                                                    "name":  "id_token",
+                                                                    "type":  "text",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                },
+                                                   "access_token_expires_at":  {
+                                                                                   "name":  "access_token_expires_at",
+                                                                                   "type":  "integer",
+                                                                                   "primaryKey":  false,
+                                                                                   "notNull":  false,
+                                                                                   "autoincrement":  false
+                                                                               },
+                                                   "refresh_token_expires_at":  {
+                                                                                    "name":  "refresh_token_expires_at",
+                                                                                    "type":  "integer",
+                                                                                    "primaryKey":  false,
+                                                                                    "notNull":  false,
+                                                                                    "autoincrement":  false
+                                                                                },
+                                                   "scope":  {
+                                                                 "name":  "scope",
+                                                                 "type":  "text",
+                                                                 "primaryKey":  false,
+                                                                 "notNull":  false,
+                                                                 "autoincrement":  false
+                                                             },
+                                                   "password":  {
+                                                                    "name":  "password",
+                                                                    "type":  "text",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                },
+                                                   "created_at":  {
+                                                                      "name":  "created_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false,
+                                                                      "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                                  },
+                                                   "updated_at":  {
+                                                                      "name":  "updated_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  }
+                                               },
+                                   "indexes":  {
+                                                   "account_userId_idx":  {
+                                                                              "name":  "account_userId_idx",
+                                                                              "columns":  [
+                                                                                              "user_id"
+                                                                                          ],
+                                                                              "isUnique":  false
+                                                                          }
+                                               },
+                                   "foreignKeys":  {
+                                                       "account_user_id_user_id_fk":  {
+                                                                                          "name":  "account_user_id_user_id_fk",
+                                                                                          "tableFrom":  "account",
+                                                                                          "tableTo":  "user",
+                                                                                          "columnsFrom":  [
+                                                                                                              "user_id"
+                                                                                                          ],
+                                                                                          "columnsTo":  [
+                                                                                                            "id"
+                                                                                                        ],
+                                                                                          "onDelete":  "cascade",
+                                                                                          "onUpdate":  "no action"
+                                                                                      }
+                                                   },
+                                   "compositePrimaryKeys":  {
+
+                                                            },
+                                   "uniqueConstraints":  {
+
+                                                         },
+                                   "checkConstraints":  {
+
+                                                        }
+                               },
+                   "session":  {
+                                   "name":  "session",
+                                   "columns":  {
+                                                   "id":  {
+                                                              "name":  "id",
+                                                              "type":  "text",
+                                                              "primaryKey":  true,
+                                                              "notNull":  true,
+                                                              "autoincrement":  false
+                                                          },
+                                                   "expires_at":  {
+                                                                      "name":  "expires_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                   "token":  {
+                                                                 "name":  "token",
+                                                                 "type":  "text",
+                                                                 "primaryKey":  false,
+                                                                 "notNull":  true,
+                                                                 "autoincrement":  false
+                                                             },
+                                                   "created_at":  {
+                                                                      "name":  "created_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false,
+                                                                      "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                                  },
+                                                   "updated_at":  {
+                                                                      "name":  "updated_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                   "ip_address":  {
+                                                                      "name":  "ip_address",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  false,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                   "user_agent":  {
+                                                                      "name":  "user_agent",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  false,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                   "user_id":  {
+                                                                   "name":  "user_id",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false
+                                                               },
+                                                   "impersonated_by":  {
+                                                                           "name":  "impersonated_by",
+                                                                           "type":  "text",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  false,
+                                                                           "autoincrement":  false
+                                                                       }
+                                               },
+                                   "indexes":  {
+                                                   "session_token_unique":  {
+                                                                                "name":  "session_token_unique",
+                                                                                "columns":  [
+                                                                                                "token"
+                                                                                            ],
+                                                                                "isUnique":  true
+                                                                            },
+                                                   "session_userId_idx":  {
+                                                                              "name":  "session_userId_idx",
+                                                                              "columns":  [
+                                                                                              "user_id"
+                                                                                          ],
+                                                                              "isUnique":  false
+                                                                          }
+                                               },
+                                   "foreignKeys":  {
+                                                       "session_user_id_user_id_fk":  {
+                                                                                          "name":  "session_user_id_user_id_fk",
+                                                                                          "tableFrom":  "session",
+                                                                                          "tableTo":  "user",
+                                                                                          "columnsFrom":  [
+                                                                                                              "user_id"
+                                                                                                          ],
+                                                                                          "columnsTo":  [
+                                                                                                            "id"
+                                                                                                        ],
+                                                                                          "onDelete":  "cascade",
+                                                                                          "onUpdate":  "no action"
+                                                                                      }
+                                                   },
+                                   "compositePrimaryKeys":  {
+
+                                                            },
+                                   "uniqueConstraints":  {
+
+                                                         },
+                                   "checkConstraints":  {
+
+                                                        }
+                               },
+                   "user":  {
+                                "name":  "user",
+                                "columns":  {
+                                                "id":  {
+                                                           "name":  "id",
+                                                           "type":  "text",
+                                                           "primaryKey":  true,
+                                                           "notNull":  true,
+                                                           "autoincrement":  false
+                                                       },
+                                                "name":  {
+                                                             "name":  "name",
+                                                             "type":  "text",
+                                                             "primaryKey":  false,
+                                                             "notNull":  true,
+                                                             "autoincrement":  false
+                                                         },
+                                                "email":  {
+                                                              "name":  "email",
+                                                              "type":  "text",
+                                                              "primaryKey":  false,
+                                                              "notNull":  true,
+                                                              "autoincrement":  false
+                                                          },
+                                                "email_verified":  {
+                                                                       "name":  "email_verified",
+                                                                       "type":  "integer",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false,
+                                                                       "default":  false
+                                                                   },
+                                                "image":  {
+                                                              "name":  "image",
+                                                              "type":  "text",
+                                                              "primaryKey":  false,
+                                                              "notNull":  false,
+                                                              "autoincrement":  false
+                                                          },
+                                                "created_at":  {
+                                                                   "name":  "created_at",
+                                                                   "type":  "integer",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false,
+                                                                   "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                               },
+                                                "updated_at":  {
+                                                                   "name":  "updated_at",
+                                                                   "type":  "integer",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false,
+                                                                   "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                               },
+                                                "role":  {
+                                                             "name":  "role",
+                                                             "type":  "text",
+                                                             "primaryKey":  false,
+                                                             "notNull":  false,
+                                                             "autoincrement":  false
+                                                         },
+                                                "banned":  {
+                                                               "name":  "banned",
+                                                               "type":  "integer",
+                                                               "primaryKey":  false,
+                                                               "notNull":  false,
+                                                               "autoincrement":  false,
+                                                               "default":  false
+                                                           },
+                                                "ban_reason":  {
+                                                                   "name":  "ban_reason",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  false,
+                                                                   "autoincrement":  false
+                                                               },
+                                                "ban_expires":  {
+                                                                    "name":  "ban_expires",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                }
+                                            },
+                                "indexes":  {
+                                                "user_email_unique":  {
+                                                                          "name":  "user_email_unique",
+                                                                          "columns":  [
+                                                                                          "email"
+                                                                                      ],
+                                                                          "isUnique":  true
+                                                                      }
+                                            },
+                                "foreignKeys":  {
+
+                                                },
+                                "compositePrimaryKeys":  {
+
+                                                         },
+                                "uniqueConstraints":  {
+
+                                                      },
+                                "checkConstraints":  {
+
+                                                     }
+                            },
+                   "verification":  {
+                                        "name":  "verification",
+                                        "columns":  {
+                                                        "id":  {
+                                                                   "name":  "id",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  true,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false
+                                                               },
+                                                        "identifier":  {
+                                                                           "name":  "identifier",
+                                                                           "type":  "text",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false
+                                                                       },
+                                                        "value":  {
+                                                                      "name":  "value",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                        "expires_at":  {
+                                                                           "name":  "expires_at",
+                                                                           "type":  "integer",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false
+                                                                       },
+                                                        "created_at":  {
+                                                                           "name":  "created_at",
+                                                                           "type":  "integer",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false,
+                                                                           "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                                       },
+                                                        "updated_at":  {
+                                                                           "name":  "updated_at",
+                                                                           "type":  "integer",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false,
+                                                                           "default":  "(cast(unixepoch(\u0027subsecond\u0027) * 1000 as integer))"
+                                                                       }
+                                                    },
+                                        "indexes":  {
+                                                        "verification_identifier_idx":  {
+                                                                                            "name":  "verification_identifier_idx",
+                                                                                            "columns":  [
+                                                                                                            "identifier"
+                                                                                                        ],
+                                                                                            "isUnique":  false
+                                                                                        }
+                                                    },
+                                        "foreignKeys":  {
+
+                                                        },
+                                        "compositePrimaryKeys":  {
+
+                                                                 },
+                                        "uniqueConstraints":  {
+
+                                                              },
+                                        "checkConstraints":  {
+
+                                                             }
+                                    },
+                   "comments":  {
+                                    "name":  "comments",
+                                    "columns":  {
+                                                    "id":  {
+                                                               "name":  "id",
+                                                               "type":  "integer",
+                                                               "primaryKey":  true,
+                                                               "notNull":  true,
+                                                               "autoincrement":  true
+                                                           },
+                                                    "content":  {
+                                                                    "name":  "content",
+                                                                    "type":  "text",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                },
+                                                    "root_id":  {
+                                                                    "name":  "root_id",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                },
+                                                    "reply_to_comment_id":  {
+                                                                                "name":  "reply_to_comment_id",
+                                                                                "type":  "integer",
+                                                                                "primaryKey":  false,
+                                                                                "notNull":  false,
+                                                                                "autoincrement":  false
+                                                                            },
+                                                    "status":  {
+                                                                   "name":  "status",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false,
+                                                                   "default":  "\u0027verifying\u0027"
+                                                               },
+                                                    "ai_reason":  {
+                                                                      "name":  "ai_reason",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  false,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                    "post_id":  {
+                                                                    "name":  "post_id",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  false
+                                                                },
+                                                    "user_id":  {
+                                                                    "name":  "user_id",
+                                                                    "type":  "text",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  false,
+                                                                    "autoincrement":  false
+                                                                },
+                                                    "created_at":  {
+                                                                       "name":  "created_at",
+                                                                       "type":  "integer",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false,
+                                                                       "default":  "(unixepoch())"
+                                                                   },
+                                                    "updated_at":  {
+                                                                       "name":  "updated_at",
+                                                                       "type":  "integer",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false,
+                                                                       "default":  "(unixepoch())"
+                                                                   }
+                                                },
+                                    "indexes":  {
+                                                    "comments_post_root_created_idx":  {
+                                                                                           "name":  "comments_post_root_created_idx",
+                                                                                           "columns":  [
+                                                                                                           "post_id",
+                                                                                                           "root_id",
+                                                                                                           "created_at"
+                                                                                                       ],
+                                                                                           "isUnique":  false
+                                                                                       },
+                                                    "comments_user_created_idx":  {
+                                                                                      "name":  "comments_user_created_idx",
+                                                                                      "columns":  [
+                                                                                                      "user_id",
+                                                                                                      "created_at"
+                                                                                                  ],
+                                                                                      "isUnique":  false
+                                                                                  },
+                                                    "comments_status_created_idx":  {
+                                                                                        "name":  "comments_status_created_idx",
+                                                                                        "columns":  [
+                                                                                                        "status",
+                                                                                                        "created_at"
+                                                                                                    ],
+                                                                                        "isUnique":  false
+                                                                                    },
+                                                    "comments_global_created_idx":  {
+                                                                                        "name":  "comments_global_created_idx",
+                                                                                        "columns":  [
+                                                                                                        "created_at"
+                                                                                                    ],
+                                                                                        "isUnique":  false
+                                                                                    }
+                                                },
+                                    "foreignKeys":  {
+                                                        "comments_root_id_comments_id_fk":  {
+                                                                                                "name":  "comments_root_id_comments_id_fk",
+                                                                                                "tableFrom":  "comments",
+                                                                                                "tableTo":  "comments",
+                                                                                                "columnsFrom":  [
+                                                                                                                    "root_id"
+                                                                                                                ],
+                                                                                                "columnsTo":  [
+                                                                                                                  "id"
+                                                                                                              ],
+                                                                                                "onDelete":  "cascade",
+                                                                                                "onUpdate":  "no action"
+                                                                                            },
+                                                        "comments_reply_to_comment_id_comments_id_fk":  {
+                                                                                                            "name":  "comments_reply_to_comment_id_comments_id_fk",
+                                                                                                            "tableFrom":  "comments",
+                                                                                                            "tableTo":  "comments",
+                                                                                                            "columnsFrom":  [
+                                                                                                                                "reply_to_comment_id"
+                                                                                                                            ],
+                                                                                                            "columnsTo":  [
+                                                                                                                              "id"
+                                                                                                                          ],
+                                                                                                            "onDelete":  "set null",
+                                                                                                            "onUpdate":  "no action"
+                                                                                                        },
+                                                        "comments_post_id_posts_id_fk":  {
+                                                                                             "name":  "comments_post_id_posts_id_fk",
+                                                                                             "tableFrom":  "comments",
+                                                                                             "tableTo":  "posts",
+                                                                                             "columnsFrom":  [
+                                                                                                                 "post_id"
+                                                                                                             ],
+                                                                                             "columnsTo":  [
+                                                                                                               "id"
+                                                                                                           ],
+                                                                                             "onDelete":  "cascade",
+                                                                                             "onUpdate":  "no action"
+                                                                                         },
+                                                        "comments_user_id_user_id_fk":  {
+                                                                                            "name":  "comments_user_id_user_id_fk",
+                                                                                            "tableFrom":  "comments",
+                                                                                            "tableTo":  "user",
+                                                                                            "columnsFrom":  [
+                                                                                                                "user_id"
+                                                                                                            ],
+                                                                                            "columnsTo":  [
+                                                                                                              "id"
+                                                                                                          ],
+                                                                                            "onDelete":  "set null",
+                                                                                            "onUpdate":  "no action"
+                                                                                        }
+                                                    },
+                                    "compositePrimaryKeys":  {
+
+                                                             },
+                                    "uniqueConstraints":  {
+
+                                                          },
+                                    "checkConstraints":  {
+
+                                                         }
+                                },
+                   "email_unsubscriptions":  {
+                                                 "name":  "email_unsubscriptions",
+                                                 "columns":  {
+                                                                 "user_id":  {
+                                                                                 "name":  "user_id",
+                                                                                 "type":  "text",
+                                                                                 "primaryKey":  false,
+                                                                                 "notNull":  true,
+                                                                                 "autoincrement":  false
+                                                                             },
+                                                                 "type":  {
+                                                                              "name":  "type",
+                                                                              "type":  "text",
+                                                                              "primaryKey":  false,
+                                                                              "notNull":  true,
+                                                                              "autoincrement":  false
+                                                                          },
+                                                                 "created_at":  {
+                                                                                    "name":  "created_at",
+                                                                                    "type":  "integer",
+                                                                                    "primaryKey":  false,
+                                                                                    "notNull":  true,
+                                                                                    "autoincrement":  false,
+                                                                                    "default":  "(unixepoch())"
+                                                                                }
+                                                             },
+                                                 "indexes":  {
+
+                                                             },
+                                                 "foreignKeys":  {
+                                                                     "email_unsubscriptions_user_id_user_id_fk":  {
+                                                                                                                      "name":  "email_unsubscriptions_user_id_user_id_fk",
+                                                                                                                      "tableFrom":  "email_unsubscriptions",
+                                                                                                                      "tableTo":  "user",
+                                                                                                                      "columnsFrom":  [
+                                                                                                                                          "user_id"
+                                                                                                                                      ],
+                                                                                                                      "columnsTo":  [
+                                                                                                                                        "id"
+                                                                                                                                    ],
+                                                                                                                      "onDelete":  "cascade",
+                                                                                                                      "onUpdate":  "no action"
+                                                                                                                  }
+                                                                 },
+                                                 "compositePrimaryKeys":  {
+                                                                              "email_unsubscriptions_user_id_type_pk":  {
+                                                                                                                            "columns":  [
+                                                                                                                                            "user_id",
+                                                                                                                                            "type"
+                                                                                                                                        ],
+                                                                                                                            "name":  "email_unsubscriptions_user_id_type_pk"
+                                                                                                                        }
+                                                                          },
+                                                 "uniqueConstraints":  {
+
+                                                                       },
+                                                 "checkConstraints":  {
+
+                                                                      }
+                                             },
+                   "system_config":  {
+                                         "name":  "system_config",
+                                         "columns":  {
+                                                         "id":  {
+                                                                    "name":  "id",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  true,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  true
+                                                                },
+                                                         "config_json":  {
+                                                                             "name":  "config_json",
+                                                                             "type":  "text",
+                                                                             "primaryKey":  false,
+                                                                             "notNull":  false,
+                                                                             "autoincrement":  false
+                                                                         },
+                                                         "updated_at":  {
+                                                                            "name":  "updated_at",
+                                                                            "type":  "integer",
+                                                                            "primaryKey":  false,
+                                                                            "notNull":  true,
+                                                                            "autoincrement":  false,
+                                                                            "default":  "(unixepoch())"
+                                                                        }
+                                                     },
+                                         "indexes":  {
+
+                                                     },
+                                         "foreignKeys":  {
+
+                                                         },
+                                         "compositePrimaryKeys":  {
+
+                                                                  },
+                                         "uniqueConstraints":  {
+
+                                                               },
+                                         "checkConstraints":  {
+
+                                                              }
+                                     },
+                   "friend_links":  {
+                                        "name":  "friend_links",
+                                        "columns":  {
+                                                        "id":  {
+                                                                   "name":  "id",
+                                                                   "type":  "integer",
+                                                                   "primaryKey":  true,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  true
+                                                               },
+                                                        "site_name":  {
+                                                                          "name":  "site_name",
+                                                                          "type":  "text",
+                                                                          "primaryKey":  false,
+                                                                          "notNull":  true,
+                                                                          "autoincrement":  false
+                                                                      },
+                                                        "site_url":  {
+                                                                         "name":  "site_url",
+                                                                         "type":  "text",
+                                                                         "primaryKey":  false,
+                                                                         "notNull":  true,
+                                                                         "autoincrement":  false
+                                                                     },
+                                                        "description":  {
+                                                                            "name":  "description",
+                                                                            "type":  "text",
+                                                                            "primaryKey":  false,
+                                                                            "notNull":  false,
+                                                                            "autoincrement":  false
+                                                                        },
+                                                        "logo_url":  {
+                                                                         "name":  "logo_url",
+                                                                         "type":  "text",
+                                                                         "primaryKey":  false,
+                                                                         "notNull":  false,
+                                                                         "autoincrement":  false
+                                                                     },
+                                                        "contact_email":  {
+                                                                              "name":  "contact_email",
+                                                                              "type":  "text",
+                                                                              "primaryKey":  false,
+                                                                              "notNull":  false,
+                                                                              "autoincrement":  false
+                                                                          },
+                                                        "status":  {
+                                                                       "name":  "status",
+                                                                       "type":  "text",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false,
+                                                                       "default":  "\u0027pending\u0027"
+                                                                   },
+                                                        "rejection_reason":  {
+                                                                                 "name":  "rejection_reason",
+                                                                                 "type":  "text",
+                                                                                 "primaryKey":  false,
+                                                                                 "notNull":  false,
+                                                                                 "autoincrement":  false
+                                                                             },
+                                                        "user_id":  {
+                                                                        "name":  "user_id",
+                                                                        "type":  "text",
+                                                                        "primaryKey":  false,
+                                                                        "notNull":  false,
+                                                                        "autoincrement":  false
+                                                                    },
+                                                        "created_at":  {
+                                                                           "name":  "created_at",
+                                                                           "type":  "integer",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false,
+                                                                           "default":  "(unixepoch())"
+                                                                       },
+                                                        "updated_at":  {
+                                                                           "name":  "updated_at",
+                                                                           "type":  "integer",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false,
+                                                                           "default":  "(unixepoch())"
+                                                                       }
+                                                    },
+                                        "indexes":  {
+                                                        "friend_links_status_created_idx":  {
+                                                                                                "name":  "friend_links_status_created_idx",
+                                                                                                "columns":  [
+                                                                                                                "status",
+                                                                                                                "created_at"
+                                                                                                            ],
+                                                                                                "isUnique":  false
+                                                                                            },
+                                                        "friend_links_user_idx":  {
+                                                                                      "name":  "friend_links_user_idx",
+                                                                                      "columns":  [
+                                                                                                      "user_id"
+                                                                                                  ],
+                                                                                      "isUnique":  false
+                                                                                  }
+                                                    },
+                                        "foreignKeys":  {
+                                                            "friend_links_user_id_user_id_fk":  {
+                                                                                                    "name":  "friend_links_user_id_user_id_fk",
+                                                                                                    "tableFrom":  "friend_links",
+                                                                                                    "tableTo":  "user",
+                                                                                                    "columnsFrom":  [
+                                                                                                                        "user_id"
+                                                                                                                    ],
+                                                                                                    "columnsTo":  [
+                                                                                                                      "id"
+                                                                                                                  ],
+                                                                                                    "onDelete":  "cascade",
+                                                                                                    "onUpdate":  "no action"
+                                                                                                }
+                                                        },
+                                        "compositePrimaryKeys":  {
+
+                                                                 },
+                                        "uniqueConstraints":  {
+
+                                                              },
+                                        "checkConstraints":  {
+
+                                                             }
+                                    },
+                   "media":  {
+                                 "name":  "media",
+                                 "columns":  {
+                                                 "id":  {
+                                                            "name":  "id",
+                                                            "type":  "integer",
+                                                            "primaryKey":  true,
+                                                            "notNull":  true,
+                                                            "autoincrement":  true
+                                                        },
+                                                 "key":  {
+                                                             "name":  "key",
+                                                             "type":  "text",
+                                                             "primaryKey":  false,
+                                                             "notNull":  true,
+                                                             "autoincrement":  false
+                                                         },
+                                                 "url":  {
+                                                             "name":  "url",
+                                                             "type":  "text",
+                                                             "primaryKey":  false,
+                                                             "notNull":  true,
+                                                             "autoincrement":  false
+                                                         },
+                                                 "file_name":  {
+                                                                   "name":  "file_name",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false
+                                                               },
+                                                 "width":  {
+                                                               "name":  "width",
+                                                               "type":  "integer",
+                                                               "primaryKey":  false,
+                                                               "notNull":  false,
+                                                               "autoincrement":  false
+                                                           },
+                                                 "height":  {
+                                                                "name":  "height",
+                                                                "type":  "integer",
+                                                                "primaryKey":  false,
+                                                                "notNull":  false,
+                                                                "autoincrement":  false
+                                                            },
+                                                 "mime_type":  {
+                                                                   "name":  "mime_type",
+                                                                   "type":  "text",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false
+                                                               },
+                                                 "size_in_bytes":  {
+                                                                       "name":  "size_in_bytes",
+                                                                       "type":  "integer",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false
+                                                                   },
+                                                 "created_at":  {
+                                                                    "name":  "created_at",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  false,
+                                                                    "default":  "(unixepoch())"
+                                                                }
+                                             },
+                                 "indexes":  {
+                                                 "media_key_unique":  {
+                                                                          "name":  "media_key_unique",
+                                                                          "columns":  [
+                                                                                          "key"
+                                                                                      ],
+                                                                          "isUnique":  true
+                                                                      },
+                                                 "created_at_idx_media":  {
+                                                                              "name":  "created_at_idx_media",
+                                                                              "columns":  [
+                                                                                              "created_at"
+                                                                                          ],
+                                                                              "isUnique":  false
+                                                                          }
+                                             },
+                                 "foreignKeys":  {
+
+                                                 },
+                                 "compositePrimaryKeys":  {
+
+                                                          },
+                                 "uniqueConstraints":  {
+
+                                                       },
+                                 "checkConstraints":  {
+
+                                                      }
+                             },
+                   "post_media":  {
+                                      "name":  "post_media",
+                                      "columns":  {
+                                                      "post_id":  {
+                                                                      "name":  "post_id",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                      "media_id":  {
+                                                                       "name":  "media_id",
+                                                                       "type":  "integer",
+                                                                       "primaryKey":  false,
+                                                                       "notNull":  true,
+                                                                       "autoincrement":  false
+                                                                   }
+                                                  },
+                                      "indexes":  {
+
+                                                  },
+                                      "foreignKeys":  {
+                                                          "post_media_post_id_posts_id_fk":  {
+                                                                                                 "name":  "post_media_post_id_posts_id_fk",
+                                                                                                 "tableFrom":  "post_media",
+                                                                                                 "tableTo":  "posts",
+                                                                                                 "columnsFrom":  [
+                                                                                                                     "post_id"
+                                                                                                                 ],
+                                                                                                 "columnsTo":  [
+                                                                                                                   "id"
+                                                                                                               ],
+                                                                                                 "onDelete":  "cascade",
+                                                                                                 "onUpdate":  "no action"
+                                                                                             },
+                                                          "post_media_media_id_media_id_fk":  {
+                                                                                                  "name":  "post_media_media_id_media_id_fk",
+                                                                                                  "tableFrom":  "post_media",
+                                                                                                  "tableTo":  "media",
+                                                                                                  "columnsFrom":  [
+                                                                                                                      "media_id"
+                                                                                                                  ],
+                                                                                                  "columnsTo":  [
+                                                                                                                    "id"
+                                                                                                                ],
+                                                                                                  "onDelete":  "cascade",
+                                                                                                  "onUpdate":  "no action"
+                                                                                              }
+                                                      },
+                                      "compositePrimaryKeys":  {
+                                                                   "post_media_post_id_media_id_pk":  {
+                                                                                                          "columns":  [
+                                                                                                                          "post_id",
+                                                                                                                          "media_id"
+                                                                                                                      ],
+                                                                                                          "name":  "post_media_post_id_media_id_pk"
+                                                                                                      }
+                                                               },
+                                      "uniqueConstraints":  {
+
+                                                            },
+                                      "checkConstraints":  {
+
+                                                           }
+                                  },
+                   "page_views":  {
+                                      "name":  "page_views",
+                                      "columns":  {
+                                                      "id":  {
+                                                                 "name":  "id",
+                                                                 "type":  "integer",
+                                                                 "primaryKey":  true,
+                                                                 "notNull":  true,
+                                                                 "autoincrement":  true
+                                                             },
+                                                      "post_id":  {
+                                                                      "name":  "post_id",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  true,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                      "visitor_hash":  {
+                                                                           "name":  "visitor_hash",
+                                                                           "type":  "text",
+                                                                           "primaryKey":  false,
+                                                                           "notNull":  true,
+                                                                           "autoincrement":  false
+                                                                       },
+                                                      "created_at":  {
+                                                                         "name":  "created_at",
+                                                                         "type":  "integer",
+                                                                         "primaryKey":  false,
+                                                                         "notNull":  true,
+                                                                         "autoincrement":  false,
+                                                                         "default":  "(unixepoch())"
+                                                                     }
+                                                  },
+                                      "indexes":  {
+                                                      "idx_pv_post_created":  {
+                                                                                  "name":  "idx_pv_post_created",
+                                                                                  "columns":  [
+                                                                                                  "post_id",
+                                                                                                  "created_at"
+                                                                                              ],
+                                                                                  "isUnique":  false
+                                                                              },
+                                                      "idx_pv_created":  {
+                                                                             "name":  "idx_pv_created",
+                                                                             "columns":  [
+                                                                                             "created_at"
+                                                                                         ],
+                                                                             "isUnique":  false
+                                                                         }
+                                                  },
+                                      "foreignKeys":  {
+                                                          "page_views_post_id_posts_id_fk":  {
+                                                                                                 "name":  "page_views_post_id_posts_id_fk",
+                                                                                                 "tableFrom":  "page_views",
+                                                                                                 "tableTo":  "posts",
+                                                                                                 "columnsFrom":  [
+                                                                                                                     "post_id"
+                                                                                                                 ],
+                                                                                                 "columnsTo":  [
+                                                                                                                   "id"
+                                                                                                               ],
+                                                                                                 "onDelete":  "cascade",
+                                                                                                 "onUpdate":  "no action"
+                                                                                             }
+                                                      },
+                                      "compositePrimaryKeys":  {
+
+                                                               },
+                                      "uniqueConstraints":  {
+
+                                                            },
+                                      "checkConstraints":  {
+
+                                                           }
+                                  },
+                   "post_revisions":  {
+                                          "name":  "post_revisions",
+                                          "columns":  {
+                                                          "id":  {
+                                                                     "name":  "id",
+                                                                     "type":  "integer",
+                                                                     "primaryKey":  true,
+                                                                     "notNull":  true,
+                                                                     "autoincrement":  true
+                                                                 },
+                                                          "post_id":  {
+                                                                          "name":  "post_id",
+                                                                          "type":  "integer",
+                                                                          "primaryKey":  false,
+                                                                          "notNull":  true,
+                                                                          "autoincrement":  false
+                                                                      },
+                                                          "reason":  {
+                                                                         "name":  "reason",
+                                                                         "type":  "text",
+                                                                         "primaryKey":  false,
+                                                                         "notNull":  true,
+                                                                         "autoincrement":  false,
+                                                                         "default":  "\u0027auto\u0027"
+                                                                     },
+                                                          "snapshot_json":  {
+                                                                                "name":  "snapshot_json",
+                                                                                "type":  "text",
+                                                                                "primaryKey":  false,
+                                                                                "notNull":  true,
+                                                                                "autoincrement":  false
+                                                                            },
+                                                          "snapshot_hash":  {
+                                                                                "name":  "snapshot_hash",
+                                                                                "type":  "text",
+                                                                                "primaryKey":  false,
+                                                                                "notNull":  true,
+                                                                                "autoincrement":  false
+                                                                            },
+                                                          "restored_from_revision_id":  {
+                                                                                            "name":  "restored_from_revision_id",
+                                                                                            "type":  "integer",
+                                                                                            "primaryKey":  false,
+                                                                                            "notNull":  false,
+                                                                                            "autoincrement":  false
+                                                                                        },
+                                                          "created_at":  {
+                                                                             "name":  "created_at",
+                                                                             "type":  "integer",
+                                                                             "primaryKey":  false,
+                                                                             "notNull":  true,
+                                                                             "autoincrement":  false,
+                                                                             "default":  "(unixepoch())"
+                                                                         }
+                                                      },
+                                          "indexes":  {
+                                                          "post_revisions_post_created_idx":  {
+                                                                                                  "name":  "post_revisions_post_created_idx",
+                                                                                                  "columns":  [
+                                                                                                                  "post_id",
+                                                                                                                  "created_at"
+                                                                                                              ],
+                                                                                                  "isUnique":  false
+                                                                                              },
+                                                          "post_revisions_post_hash_idx":  {
+                                                                                               "name":  "post_revisions_post_hash_idx",
+                                                                                               "columns":  [
+                                                                                                               "post_id",
+                                                                                                               "snapshot_hash"
+                                                                                                           ],
+                                                                                               "isUnique":  false
+                                                                                           }
+                                                      },
+                                          "foreignKeys":  {
+                                                              "post_revisions_post_id_posts_id_fk":  {
+                                                                                                         "name":  "post_revisions_post_id_posts_id_fk",
+                                                                                                         "tableFrom":  "post_revisions",
+                                                                                                         "tableTo":  "posts",
+                                                                                                         "columnsFrom":  [
+                                                                                                                             "post_id"
+                                                                                                                         ],
+                                                                                                         "columnsTo":  [
+                                                                                                                           "id"
+                                                                                                                       ],
+                                                                                                         "onDelete":  "cascade",
+                                                                                                         "onUpdate":  "no action"
+                                                                                                     }
+                                                          },
+                                          "compositePrimaryKeys":  {
+
+                                                                   },
+                                          "uniqueConstraints":  {
+
+                                                                },
+                                          "checkConstraints":  {
+
+                                                               }
+                                      },
+                   "post_tags":  {
+                                     "name":  "post_tags",
+                                     "columns":  {
+                                                     "post_id":  {
+                                                                     "name":  "post_id",
+                                                                     "type":  "integer",
+                                                                     "primaryKey":  false,
+                                                                     "notNull":  true,
+                                                                     "autoincrement":  false
+                                                                 },
+                                                     "tag_id":  {
+                                                                    "name":  "tag_id",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  false
+                                                                }
+                                                 },
+                                     "indexes":  {
+                                                     "post_tags_tag_idx":  {
+                                                                               "name":  "post_tags_tag_idx",
+                                                                               "columns":  [
+                                                                                               "tag_id"
+                                                                                           ],
+                                                                               "isUnique":  false
+                                                                           }
+                                                 },
+                                     "foreignKeys":  {
+                                                         "post_tags_post_id_posts_id_fk":  {
+                                                                                               "name":  "post_tags_post_id_posts_id_fk",
+                                                                                               "tableFrom":  "post_tags",
+                                                                                               "tableTo":  "posts",
+                                                                                               "columnsFrom":  [
+                                                                                                                   "post_id"
+                                                                                                               ],
+                                                                                               "columnsTo":  [
+                                                                                                                 "id"
+                                                                                                             ],
+                                                                                               "onDelete":  "cascade",
+                                                                                               "onUpdate":  "no action"
+                                                                                           },
+                                                         "post_tags_tag_id_tags_id_fk":  {
+                                                                                             "name":  "post_tags_tag_id_tags_id_fk",
+                                                                                             "tableFrom":  "post_tags",
+                                                                                             "tableTo":  "tags",
+                                                                                             "columnsFrom":  [
+                                                                                                                 "tag_id"
+                                                                                                             ],
+                                                                                             "columnsTo":  [
+                                                                                                               "id"
+                                                                                                           ],
+                                                                                             "onDelete":  "cascade",
+                                                                                             "onUpdate":  "no action"
+                                                                                         }
+                                                     },
+                                     "compositePrimaryKeys":  {
+                                                                  "post_tags_post_id_tag_id_pk":  {
+                                                                                                      "columns":  [
+                                                                                                                      "post_id",
+                                                                                                                      "tag_id"
+                                                                                                                  ],
+                                                                                                      "name":  "post_tags_post_id_tag_id_pk"
+                                                                                                  }
+                                                              },
+                                     "uniqueConstraints":  {
+
+                                                           },
+                                     "checkConstraints":  {
+
+                                                          }
+                                 },
+                   "posts":  {
+                                 "name":  "posts",
+                                 "columns":  {
+                                                 "id":  {
+                                                            "name":  "id",
+                                                            "type":  "integer",
+                                                            "primaryKey":  true,
+                                                            "notNull":  true,
+                                                            "autoincrement":  true
+                                                        },
+                                                 "title":  {
+                                                               "name":  "title",
+                                                               "type":  "text",
+                                                               "primaryKey":  false,
+                                                               "notNull":  true,
+                                                               "autoincrement":  false
+                                                           },
+                                                 "summary":  {
+                                                                 "name":  "summary",
+                                                                 "type":  "text",
+                                                                 "primaryKey":  false,
+                                                                 "notNull":  false,
+                                                                 "autoincrement":  false
+                                                             },
+                                                 "read_time_in_minutes":  {
+                                                                              "name":  "read_time_in_minutes",
+                                                                              "type":  "integer",
+                                                                              "primaryKey":  false,
+                                                                              "notNull":  true,
+                                                                              "autoincrement":  false,
+                                                                              "default":  1
+                                                                          },
+                                                 "slug":  {
+                                                              "name":  "slug",
+                                                              "type":  "text",
+                                                              "primaryKey":  false,
+                                                              "notNull":  true,
+                                                              "autoincrement":  false
+                                                          },
+                                                 "content_json":  {
+                                                                      "name":  "content_json",
+                                                                      "type":  "text",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  false,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                 "public_content_json":  {
+                                                                             "name":  "public_content_json",
+                                                                             "type":  "text",
+                                                                             "primaryKey":  false,
+                                                                             "notNull":  false,
+                                                                             "autoincrement":  false
+                                                                         },
+                                                 "status":  {
+                                                                "name":  "status",
+                                                                "type":  "text",
+                                                                "primaryKey":  false,
+                                                                "notNull":  true,
+                                                                "autoincrement":  false,
+                                                                "default":  "\u0027draft\u0027"
+                                                            },
+                                                 "published_at":  {
+                                                                      "name":  "published_at",
+                                                                      "type":  "integer",
+                                                                      "primaryKey":  false,
+                                                                      "notNull":  false,
+                                                                      "autoincrement":  false
+                                                                  },
+                                                 "pinned_at":  {
+                                                                   "name":  "pinned_at",
+                                                                   "type":  "integer",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  false,
+                                                                   "autoincrement":  false
+                                                               },
+                                                 "created_at":  {
+                                                                    "name":  "created_at",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  false,
+                                                                    "default":  "(unixepoch())"
+                                                                },
+                                                 "updated_at":  {
+                                                                    "name":  "updated_at",
+                                                                    "type":  "integer",
+                                                                    "primaryKey":  false,
+                                                                    "notNull":  true,
+                                                                    "autoincrement":  false,
+                                                                    "default":  "(unixepoch())"
+                                                                }
+                                             },
+                                 "indexes":  {
+                                                 "posts_slug_unique":  {
+                                                                           "name":  "posts_slug_unique",
+                                                                           "columns":  [
+                                                                                           "slug"
+                                                                                       ],
+                                                                           "isUnique":  true
+                                                                       },
+                                                 "published_at_idx":  {
+                                                                          "name":  "published_at_idx",
+                                                                          "columns":  [
+                                                                                          "published_at",
+                                                                                          "status"
+                                                                                      ],
+                                                                          "isUnique":  false
+                                                                      },
+                                                 "created_at_idx":  {
+                                                                        "name":  "created_at_idx",
+                                                                        "columns":  [
+                                                                                        "created_at"
+                                                                                    ],
+                                                                        "isUnique":  false
+                                                                    }
+                                             },
+                                 "foreignKeys":  {
+
+                                                 },
+                                 "compositePrimaryKeys":  {
+
+                                                          },
+                                 "uniqueConstraints":  {
+
+                                                       },
+                                 "checkConstraints":  {
+
+                                                      }
+                             },
+                   "tags":  {
+                                "name":  "tags",
+                                "columns":  {
+                                                "id":  {
+                                                           "name":  "id",
+                                                           "type":  "integer",
+                                                           "primaryKey":  true,
+                                                           "notNull":  true,
+                                                           "autoincrement":  true
+                                                       },
+                                                "name":  {
+                                                             "name":  "name",
+                                                             "type":  "text",
+                                                             "primaryKey":  false,
+                                                             "notNull":  true,
+                                                             "autoincrement":  false
+                                                         },
+                                                "created_at":  {
+                                                                   "name":  "created_at",
+                                                                   "type":  "integer",
+                                                                   "primaryKey":  false,
+                                                                   "notNull":  true,
+                                                                   "autoincrement":  false,
+                                                                   "default":  "(unixepoch())"
+                                                               }
+                                            },
+                                "indexes":  {
+                                                "tags_name_unique":  {
+                                                                         "name":  "tags_name_unique",
+                                                                         "columns":  [
+                                                                                         "name"
+                                                                                     ],
+                                                                         "isUnique":  true
+                                                                     }
+                                            },
+                                "foreignKeys":  {
+
+                                                },
+                                "compositePrimaryKeys":  {
+
+                                                         },
+                                "uniqueConstraints":  {
+
+                                                      },
+                                "checkConstraints":  {
+
+                                                     }
+                            },
+                   "obsidian_post_links":  {
+                                               "name":  "obsidian_post_links",
+                                               "columns":  {
+                                                               "post_id":  {
+                                                                               "name":  "post_id",
+                                                                               "type":  "integer",
+                                                                               "primaryKey":  true,
+                                                                               "notNull":  true,
+                                                                               "autoincrement":  false
+                                                                           },
+                                                               "obsidian_path":  {
+                                                                                     "name":  "obsidian_path",
+                                                                                     "type":  "text",
+                                                                                     "primaryKey":  false,
+                                                                                     "notNull":  false,
+                                                                                     "autoincrement":  false
+                                                                                 },
+                                                               "revision":  {
+                                                                                "name":  "revision",
+                                                                                "type":  "integer",
+                                                                                "primaryKey":  false,
+                                                                                "notNull":  true,
+                                                                                "autoincrement":  false,
+                                                                                "default":  1
+                                                                            },
+                                                               "content_hash":  {
+                                                                                    "name":  "content_hash",
+                                                                                    "type":  "text",
+                                                                                    "primaryKey":  false,
+                                                                                    "notNull":  true,
+                                                                                    "autoincrement":  false
+                                                                                },
+                                                               "updated_at":  {
+                                                                                  "name":  "updated_at",
+                                                                                  "type":  "integer",
+                                                                                  "primaryKey":  false,
+                                                                                  "notNull":  true,
+                                                                                  "autoincrement":  false,
+                                                                                  "default":  "(unixepoch())"
+                                                                              }
+                                                           },
+                                               "indexes":  {
+
+                                                           },
+                                               "foreignKeys":  {
+                                                                   "obsidian_post_links_post_id_posts_id_fk":  {
+                                                                                                                   "name":  "obsidian_post_links_post_id_posts_id_fk",
+                                                                                                                   "tableFrom":  "obsidian_post_links",
+                                                                                                                   "tableTo":  "posts",
+                                                                                                                   "columnsFrom":  [
+                                                                                                                                       "post_id"
+                                                                                                                                   ],
+                                                                                                                   "columnsTo":  [
+                                                                                                                                     "id"
+                                                                                                                                 ],
+                                                                                                                   "onDelete":  "cascade",
+                                                                                                                   "onUpdate":  "no action"
+                                                                                                               }
+                                                               },
+                                               "compositePrimaryKeys":  {
+
+                                                                        },
+                                               "uniqueConstraints":  {
+
+                                                                     },
+                                               "checkConstraints":  {
+
+                                                                    }
+                                           }
+               },
+    "views":  {
+
+              },
+    "enums":  {
+
+              },
+    "_meta":  {
+                  "schemas":  {
+
+                              },
+                  "tables":  {
+
+                             },
+                  "columns":  {
+
+                              }
+              },
+    "internal":  {
+                     "indexes":  {
+
+                                 }
+                 }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1774071685152,
       "tag": "0010_romantic_roland_deschain",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778457600000,
+      "tag": "0011_obsidian_post_links",
+      "breakpoints": true
     }
   ]
 }

--- a/src/features/import-export/utils/markdown-serializer.test.ts
+++ b/src/features/import-export/utils/markdown-serializer.test.ts
@@ -51,6 +51,13 @@ describe("jsonContentToMarkdown", () => {
     expect(result).toContain("hello **bold**");
   });
 
+  it("should escape markdown markers in plain text", () => {
+    const result = jsonContentToMarkdown(
+      doc(paragraph(text("literal **文本**"))),
+    );
+    expect(result).toBe("literal \\*\\*文本\\*\\*\n");
+  });
+
   it("should convert paragraph with italic", () => {
     const result = jsonContentToMarkdown(
       doc(paragraph(text("hello "), text("italic", [{ type: "italic" }]))),

--- a/src/features/import-export/utils/markdown-serializer.ts
+++ b/src/features/import-export/utils/markdown-serializer.ts
@@ -1,6 +1,10 @@
 import type { JSONContent } from "@tiptap/react";
 import { extractImageKey } from "@/features/media/utils/media.utils";
 
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_{}()[\]#+!|>~-])/g, "\\$1");
+}
+
 /**
  * JSONContent → Markdown 转换器
  *
@@ -163,9 +167,13 @@ function serializeInlineNode(
   options?: { rewriteImageSrc?: (src: string) => string },
 ): string {
   if (node.type === "text") {
-    let text = node.text ?? "";
+    const marks = node.marks ?? [];
+    const hasCodeMark = marks.some((mark) => mark.type === "code");
+    let text = hasCodeMark
+      ? (node.text ?? "").replace(/`/g, "\\`")
+      : escapeMarkdownText(node.text ?? "");
     // Apply marks in order
-    for (const mark of node.marks ?? []) {
+    for (const mark of marks) {
       text = applyMark(mark, text);
     }
     return text;

--- a/src/features/obsidian-sync/api/hono/obsidian-sync.route.ts
+++ b/src/features/obsidian-sync/api/hono/obsidian-sync.route.ts
@@ -1,0 +1,81 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import {
+  ArticleIdSchema,
+  ArticleListQuerySchema,
+  ArticlePayloadSchema,
+  UpdateArticlePayloadSchema,
+} from "@/features/obsidian-sync/schema/obsidian-sync.schema";
+import * as SyncService from "@/features/obsidian-sync/service/obsidian-sync.service";
+import { getServiceContext } from "@/lib/hono/helper";
+import { baseMiddleware } from "@/lib/hono/middlewares";
+
+const app = new Hono<{ Bindings: Env }>();
+app.use("*", baseMiddleware);
+
+function unauthorized(c: Context<{ Bindings: Env }>) {
+  return c.json(
+    { error: { code: "UNAUTHORIZED", message: "A valid bearer token is required" } },
+    401,
+    { "WWW-Authenticate": "Bearer", "Cache-Control": "no-store" },
+  );
+}
+
+function safeEqual(left: string, right: string) {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  if (leftBytes.length !== rightBytes.length) return false;
+  let difference = 0;
+  for (let index = 0; index < leftBytes.length; index += 1) {
+    difference |= (leftBytes[index] ?? 0) ^ (rightBytes[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+app.use("*", async (c, next) => {
+  const authorization = c.req.header("Authorization") ?? "";
+  const [scheme, token] = authorization.split(" ", 2);
+  const expected = c.env.OBSIDIAN_SYNC_TOKEN;
+  if (scheme !== "Bearer" || !token || !expected || !safeEqual(token, expected)) {
+    return unauthorized(c);
+  }
+  await next();
+});
+
+app.use("*", async (c, next) => {
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
+});
+
+app.get("/", zValidator("query", ArticleListQuerySchema), async (c) => {
+  const query = c.req.valid("query");
+  return c.json(await SyncService.listArticles(getServiceContext(c), query.cursor, query.limit));
+});
+
+app.post("/", zValidator("json", ArticlePayloadSchema), async (c) => {
+  const article = await SyncService.createArticle(getServiceContext(c), c.req.valid("json"));
+  return c.json(article, 201);
+});
+
+app.get("/:id", zValidator("param", ArticleIdSchema), async (c) => {
+  const article = await SyncService.getArticle(getServiceContext(c), c.req.valid("param").id);
+  if (!article) return c.json({ error: { code: "ARTICLE_NOT_FOUND", message: "Article not found" } }, 404);
+  return c.json(article);
+});
+
+app.put("/:id", zValidator("param", ArticleIdSchema), zValidator("json", UpdateArticlePayloadSchema), async (c) => {
+  const result = await SyncService.updateArticle(getServiceContext(c), c.req.valid("param").id, c.req.valid("json"));
+  if (result.conflict) return c.json({ error: { code: "REVISION_CONFLICT", message: "The remote article changed since this note was last synced", current: result.conflict } }, 409);
+  if (result.notFound) return c.json({ error: { code: "ARTICLE_NOT_FOUND", message: "Article not found" } }, 404);
+  if (!result.article) return c.json({ error: { code: "ARTICLE_NOT_FOUND", message: "Article not found" } }, 404);
+  return c.json(result.article);
+});
+
+app.delete("/:id", zValidator("param", ArticleIdSchema), async (c) => {
+  const deleted = await SyncService.deleteArticle(getServiceContext(c), c.req.valid("param").id);
+  if (!deleted) return c.json({ error: { code: "ARTICLE_NOT_FOUND", message: "Article not found" } }, 404);
+  return c.json({ success: true });
+});
+
+export default app;

--- a/src/features/obsidian-sync/data/obsidian-sync.data.ts
+++ b/src/features/obsidian-sync/data/obsidian-sync.data.ts
@@ -1,4 +1,4 @@
-import { asc, eq, gt, inArray } from "drizzle-orm";
+import { and, asc, eq, gt, inArray } from "drizzle-orm";
 import { ObsidianPostLinksTable, PostsTable } from "@/lib/db/schema";
 
 export async function findPostLink(db: DB, postId: number) {

--- a/src/features/obsidian-sync/data/obsidian-sync.data.ts
+++ b/src/features/obsidian-sync/data/obsidian-sync.data.ts
@@ -1,0 +1,86 @@
+import { asc, eq, gt, inArray } from "drizzle-orm";
+import { ObsidianPostLinksTable, PostsTable } from "@/lib/db/schema";
+
+export async function findPostLink(db: DB, postId: number) {
+  return await db.query.ObsidianPostLinksTable.findFirst({
+    where: eq(ObsidianPostLinksTable.postId, postId),
+  });
+}
+
+export async function upsertPostLink(
+  db: DB,
+  data: typeof ObsidianPostLinksTable.$inferInsert,
+) {
+  const [link] = await db
+    .insert(ObsidianPostLinksTable)
+    .values(data)
+    .onConflictDoUpdate({
+      target: ObsidianPostLinksTable.postId,
+      set: {
+        obsidianPath: data.obsidianPath,
+        revision: data.revision,
+        contentHash: data.contentHash,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  return link;
+}
+
+export async function updatePostLink(
+  db: DB,
+  postId: number,
+  data: {
+    obsidianPath?: string | null;
+    revision: number;
+    contentHash: string;
+    expectedRevision?: number;
+    expectedHash?: string;
+  },
+) {
+  const [link] = await db
+    .update(ObsidianPostLinksTable)
+    .set({
+      obsidianPath: data.obsidianPath,
+      revision: data.revision,
+      contentHash: data.contentHash,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(ObsidianPostLinksTable.postId, postId),
+        data.expectedRevision === undefined
+          ? undefined
+          : eq(ObsidianPostLinksTable.revision, data.expectedRevision),
+        data.expectedHash === undefined
+          ? undefined
+          : eq(ObsidianPostLinksTable.contentHash, data.expectedHash),
+      ),
+    )
+    .returning();
+  return link;
+}
+
+export async function deletePostLink(db: DB, postId: number) {
+  await db
+    .delete(ObsidianPostLinksTable)
+    .where(eq(ObsidianPostLinksTable.postId, postId));
+}
+
+export async function listPosts(db: DB, cursor: number, limit: number) {
+  const rows = await db
+    .select()
+    .from(PostsTable)
+    .where(gt(PostsTable.id, cursor))
+    .orderBy(asc(PostsTable.id))
+    .limit(limit + 1);
+  return { rows: rows.slice(0, limit), hasMore: rows.length > limit };
+}
+
+export async function findLinks(db: DB, postIds: number[]) {
+  if (postIds.length === 0) return [];
+  return await db
+    .select()
+    .from(ObsidianPostLinksTable)
+    .where(inArray(ObsidianPostLinksTable.postId, postIds));
+}

--- a/src/features/obsidian-sync/obsidian-sync.integration.test.ts
+++ b/src/features/obsidian-sync/obsidian-sync.integration.test.ts
@@ -1,0 +1,179 @@
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { testRequest } from "tests/test-utils";
+import { describe, expect, it } from "vitest";
+import { app } from "@/lib/hono/routes";
+import { getDb } from "@/lib/db";
+import { PostsTable } from "@/lib/db/schema";
+
+const token = "obsidian-sync-test-token";
+const content = {
+  type: "doc" as const,
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Hello from Obsidian" }],
+    },
+  ],
+};
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+describe("Obsidian sync API", () => {
+  it("rejects requests without the configured bearer token", async () => {
+    const response = await testRequest(app, "/api/obsidian/articles", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: { code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("creates, reads, conditionally updates, and deletes a linked Post", async () => {
+    const customEnv = { ...env, OBSIDIAN_SYNC_TOKEN: token, DOMAIN: "example.com" };
+    const createResponse = await testRequest(
+      app,
+      "/api/obsidian/articles",
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          title: "Obsidian Post",
+          content,
+          path: "Notes/Obsidian Post.md",
+          published: false,
+        }),
+      },
+      customEnv,
+    );
+
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as Record<string, unknown>;
+    expect(created).toMatchObject({
+      title: "Obsidian Post",
+      published: false,
+      revision: 1,
+      url: "https://example.com/post/obsidian-post",
+    });
+    expect(typeof created.id).toBe("number");
+    expect(typeof created.contentHash).toBe("string");
+
+    const id = created.id as number;
+    const updateResponse = await testRequest(
+      app,
+      `/api/obsidian/articles/${id}`,
+      {
+        method: "PUT",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          title: "Obsidian Post Updated",
+          content,
+          revision: created.revision,
+          contentHash: created.contentHash,
+          path: "Notes/Obsidian Post.md",
+          published: false,
+        }),
+      },
+      customEnv,
+    );
+    expect(updateResponse.status).toBe(200);
+    const updated = (await updateResponse.json()) as Record<string, unknown>;
+    expect(updated).toMatchObject({ title: "Obsidian Post Updated", revision: 2 });
+
+    const conflictResponse = await testRequest(
+      app,
+      `/api/obsidian/articles/${id}`,
+      {
+        method: "PUT",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          title: "Stale Update",
+          content,
+          revision: created.revision,
+          contentHash: created.contentHash,
+        }),
+      },
+      customEnv,
+    );
+    expect(conflictResponse.status).toBe(409);
+    expect(await conflictResponse.json()).toMatchObject({
+      error: { code: "REVISION_CONFLICT", current: { revision: 2 } },
+    });
+
+    const deleteResponse = await testRequest(
+      app,
+      `/api/obsidian/articles/${id}`,
+      { method: "DELETE", headers: authHeaders() },
+      customEnv,
+    );
+    expect(deleteResponse.status).toBe(200);
+    expect(await deleteResponse.json()).toEqual({ success: true });
+  });
+
+  it("lists drafts and published Posts with a cursor", async () => {
+    const customEnv = { ...env, OBSIDIAN_SYNC_TOKEN: token, DOMAIN: "example.com" };
+    const response = await testRequest(
+      app,
+      "/api/obsidian/articles?limit=10",
+      { method: "GET", headers: { Authorization: `Bearer ${token}` } },
+      customEnv,
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload.items).toEqual(expect.any(Array));
+    expect(payload).toHaveProperty("nextCursor");
+  });
+
+  it("turns a website-side edit into a revision conflict for the plugin", async () => {
+    const customEnv = { ...env, OBSIDIAN_SYNC_TOKEN: token, DOMAIN: "example.com" };
+    const createResponse = await testRequest(
+      app,
+      "/api/obsidian/articles",
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ title: "Conflict Post", content }),
+      },
+      customEnv,
+    );
+    const created = (await createResponse.json()) as Record<string, unknown>;
+    const id = created.id as number;
+
+    const db = getDb(customEnv);
+    await db
+      .update(PostsTable)
+      .set({
+        title: "Changed in website editor",
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "Remote" }] }],
+        },
+      })
+      .where(eq(PostsTable.id, id));
+
+    const response = await testRequest(
+      app,
+      `/api/obsidian/articles/${id}`,
+      {
+        method: "PUT",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          title: created.title,
+          content,
+          revision: created.revision,
+          contentHash: created.contentHash,
+        }),
+      },
+      customEnv,
+    );
+    expect(response.status).toBe(409);
+  });
+});

--- a/src/features/obsidian-sync/schema/obsidian-sync.schema.ts
+++ b/src/features/obsidian-sync/schema/obsidian-sync.schema.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { JsonContentSchema } from "@/features/posts/schema/json-content.schema";
+
+const slugSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9\u4e00-\u9fff]+(?:-[a-z0-9\u4e00-\u9fff]+)*$/);
+
+export const ArticlePayloadSchema = z.object({
+  title: z.string().trim().min(1).max(300),
+  slug: slugSchema.optional(),
+  content: JsonContentSchema.refine(
+    (value) => value?.type === "doc",
+    "content must be a TipTap document",
+  ),
+  path: z.string().max(500).optional(),
+  published: z.boolean().optional().default(false),
+});
+
+export const UpdateArticlePayloadSchema = ArticlePayloadSchema.extend({
+  revision: z.number().int().nonnegative(),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  force: z.boolean().optional().default(false),
+});
+
+export const ArticleIdSchema = z.object({ id: z.coerce.number().int().positive() });
+
+export const ArticleListQuerySchema = z.object({
+  cursor: z.coerce.number().int().nonnegative().optional().default(0),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(100),
+});
+
+export type ArticlePayload = z.infer<typeof ArticlePayloadSchema>;
+export type UpdateArticlePayload = z.infer<typeof UpdateArticlePayloadSchema>;

--- a/src/features/obsidian-sync/service/obsidian-sync.service.ts
+++ b/src/features/obsidian-sync/service/obsidian-sync.service.ts
@@ -1,0 +1,224 @@
+import type { JSONContent } from "@tiptap/react";
+import * as PostRepo from "@/features/posts/data/posts.data";
+import * as PostService from "@/features/posts/services/posts.service";
+import type {
+  ArticlePayload,
+  UpdateArticlePayload,
+} from "@/features/obsidian-sync/schema/obsidian-sync.schema";
+import {
+  deletePostLink,
+  findPostLink,
+  listPosts,
+  updatePostLink,
+  upsertPostLink,
+} from "@/features/obsidian-sync/data/obsidian-sync.data";
+import { slugify } from "@/features/posts/utils/content";
+
+export type SyncContext = DbContext & { executionCtx: ExecutionContext };
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, child]) => [key, stableValue(child)]),
+    );
+  }
+  return value;
+}
+
+export async function contentHash(title: string, content: unknown) {
+  const payload = JSON.stringify(
+    stableValue({ title: title.trim(), content }),
+  );
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(payload),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+function toISO(value: Date | null) {
+  return value?.toISOString() ?? null;
+}
+
+export interface SyncArticle {
+  id: number;
+  title: string;
+  slug: string;
+  content: JSONContent;
+  revision: number;
+  contentHash: string;
+  updatedAt: string;
+  createdAt: string;
+  published: boolean;
+  url: string;
+  obsidianUri?: string;
+}
+
+async function ensureLink(context: SyncContext, post: Awaited<ReturnType<typeof PostRepo.findPostById>>) {
+  if (!post) return undefined;
+  const existing = await findPostLink(context.db, post.id);
+  const hash = await contentHash(post.title, post.contentJson ?? { type: "doc", content: [] });
+  if (existing) {
+    if (existing.contentHash !== hash) {
+      const refreshed = await updatePostLink(context.db, post.id, {
+        obsidianPath: existing.obsidianPath,
+        revision: existing.revision + 1,
+        contentHash: hash,
+        expectedRevision: existing.revision,
+        expectedHash: existing.contentHash,
+      });
+      return refreshed ?? (await findPostLink(context.db, post.id));
+    }
+    return existing;
+  }
+  return await upsertPostLink(context.db, {
+    postId: post.id,
+    obsidianPath: null,
+    revision: 1,
+    contentHash: hash,
+  });
+}
+
+function serializeArticle(
+  context: SyncContext,
+  post: NonNullable<Awaited<ReturnType<typeof PostRepo.findPostById>>>,
+  link: NonNullable<Awaited<ReturnType<typeof ensureLink>>>,
+): SyncArticle {
+  const content = post.contentJson ?? { type: "doc", content: [] };
+  const article: SyncArticle = {
+    id: post.id,
+    title: post.title,
+    slug: post.slug,
+    content,
+    revision: link.revision,
+    contentHash: link.contentHash,
+    updatedAt: toISO(post.updatedAt) ?? new Date(0).toISOString(),
+    createdAt: toISO(post.createdAt) ?? new Date(0).toISOString(),
+    published: post.status === "published",
+    url: `https://${context.env.DOMAIN}/post/${encodeURIComponent(post.slug)}`,
+  };
+  if (link.obsidianPath) {
+    article.obsidianUri = `obsidian://open?file=${encodeURIComponent(link.obsidianPath)}`;
+  }
+  return article;
+}
+
+async function processPost(context: SyncContext, postId: number, published: boolean) {
+  await PostService.startPostProcessWorkflow(context, {
+    id: postId,
+    status: published ? "published" : "draft",
+    clientToday: new Date().toISOString().slice(0, 10),
+  });
+}
+
+export async function createArticle(context: SyncContext, input: ArticlePayload) {
+  const { slug } = await PostService.generateSlug(context, {
+    title: input.slug ?? input.title,
+  });
+  const empty = await PostService.createEmptyPost(context);
+  const publishedAt = input.published ? new Date() : null;
+  const updated = await PostService.updatePost(context, {
+    id: empty.id,
+    data: {
+      title: input.title,
+      slug: slugify(slug),
+      contentJson: input.content,
+      status: input.published ? "published" : "draft",
+      publishedAt,
+    },
+  });
+  if (updated.error || !updated.data) throw new Error("Post creation failed");
+  const hash = await contentHash(input.title, input.content);
+  const link = await upsertPostLink(context.db, {
+    postId: updated.data.id,
+    obsidianPath: input.path ?? null,
+    revision: 1,
+    contentHash: hash,
+  });
+  await processPost(context, updated.data.id, input.published ?? false);
+  return serializeArticle(context, updated.data, link);
+}
+
+export async function getArticle(context: SyncContext, id: number) {
+  const post = await PostRepo.findPostById(context.db, id);
+  if (!post) return undefined;
+  const link = await ensureLink(context, post);
+  if (!link) return undefined;
+  return serializeArticle(context, post, link);
+}
+
+export async function listArticles(context: SyncContext, cursor: number, limit: number) {
+  const page = await listPosts(context.db, cursor, limit);
+  const items: SyncArticle[] = [];
+  for (const row of page.rows) {
+    const post = await PostRepo.findPostById(context.db, row.id);
+    if (!post) continue;
+    const link = await ensureLink(context, post);
+    if (link) items.push(serializeArticle(context, post, link));
+  }
+  return {
+    items,
+    nextCursor: page.hasMore ? (page.rows.at(-1)?.id ?? null) : null,
+  };
+}
+
+export async function updateArticle(
+  context: SyncContext,
+  id: number,
+  input: UpdateArticlePayload,
+) {
+  const post = await PostRepo.findPostById(context.db, id);
+  if (!post) return { notFound: true as const };
+  const link = await ensureLink(context, post);
+  if (!link) return { notFound: true as const };
+  if (!input.force && (link.revision !== input.revision || link.contentHash !== input.contentHash)) {
+    return { conflict: serializeArticle(context, post, link) };
+  }
+
+  const nextHash = await contentHash(input.title, input.content);
+  let nextSlug = post.slug;
+  if (input.slug && input.slug !== post.slug) {
+    nextSlug = (await PostService.generateSlug(context, {
+      title: input.slug,
+      excludeId: id,
+    })).slug;
+  }
+  const updated = await PostService.updatePost(context, {
+    id,
+    data: {
+      title: input.title,
+      slug: nextSlug,
+      contentJson: input.content,
+      status: input.published ? "published" : "draft",
+      publishedAt: input.published ? post.publishedAt ?? new Date() : null,
+    },
+  });
+  if (updated.error || !updated.data) return { notFound: true as const };
+  const nextLink = await updatePostLink(context.db, id, {
+    obsidianPath: input.path ?? link.obsidianPath,
+    revision: link.revision + 1,
+    contentHash: nextHash,
+    ...(input.force
+      ? {}
+      : { expectedRevision: link.revision, expectedHash: link.contentHash }),
+  });
+  if (!nextLink) {
+    const current = await getArticle(context, id);
+    return current ? { conflict: current } : { notFound: true as const };
+  }
+  await processPost(context, id, input.published ?? false);
+  return { article: serializeArticle(context, updated.data, nextLink) };
+}
+
+export async function deleteArticle(context: SyncContext, id: number) {
+  const post = await PostRepo.findPostById(context.db, id);
+  if (!post) return false;
+  await PostService.deletePost(context, { id });
+  await deletePostLink(context.db, id);
+  return true;
+}

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -6,3 +6,4 @@ export * from "./media.table";
 export * from "./page-views.table";
 export * from "./post-revisions.table";
 export * from "./posts.table";
+export * from "./obsidian-post-links.table";

--- a/src/lib/db/schema/obsidian-post-links.table.ts
+++ b/src/lib/db/schema/obsidian-post-links.table.ts
@@ -1,0 +1,15 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { PostsTable } from "./posts.table";
+import { updatedAt } from "./helper";
+
+export const ObsidianPostLinksTable = sqliteTable("obsidian_post_links", {
+  postId: integer("post_id")
+    .primaryKey()
+    .references(() => PostsTable.id, { onDelete: "cascade" }),
+  obsidianPath: text("obsidian_path"),
+  revision: integer("revision").notNull().default(1),
+  contentHash: text("content_hash").notNull(),
+  updatedAt,
+});
+
+export type ObsidianPostLink = typeof ObsidianPostLinksTable.$inferSelect;

--- a/src/lib/env/server.env.ts
+++ b/src/lib/env/server.env.ts
@@ -30,6 +30,7 @@ const serverEnvSchema = z.object({
   PAGEVIEW_SALT: z.string().optional(),
   TURNSTILE_SECRET_KEY: z.string().optional(),
   GITHUB_TOKEN: z.string().optional(),
+  OBSIDIAN_SYNC_TOKEN: z.string().optional(),
 });
 
 export function serverEnv(env: Env) {

--- a/src/lib/hono/middlewares.ts
+++ b/src/lib/hono/middlewares.ts
@@ -73,7 +73,7 @@ export const cacheMiddleware = createMiddleware(async (c, next) => {
 
   // 排除需要 session 的 API（如 /api/auth, /api/send）
   // 但包含 public API（/api/posts, /api/post, /api/tags, /api/search）
-  const EXCLUDED_PREFIXES = ["/api/auth", "/api/send"];
+  const EXCLUDED_PREFIXES = ["/api/auth", "/api/send", "/api/obsidian"];
   if (EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix))) {
     return next();
   }

--- a/src/lib/hono/routes.ts
+++ b/src/lib/hono/routes.ts
@@ -7,6 +7,7 @@ import { handleImageRequest } from "@/features/media/service/media.service";
 import postsDetailRoute from "@/features/posts/api/hono/posts.detail.route";
 import postsListRoute from "@/features/posts/api/hono/posts.list.route";
 import postsRelatedRoute from "@/features/posts/api/hono/posts.related.route";
+import obsidianSyncRoute from "@/features/obsidian-sync/api/hono/obsidian-sync.route";
 import searchRoute from "@/features/search/api/hono/search.route";
 import siteDocumentsRoute from "@/features/site-documents/api/hono/site-documents.route";
 import tagsRoute from "@/features/tags/api/hono/tags.list.route";
@@ -41,6 +42,7 @@ const publicApi = new Hono<{ Bindings: Env }>()
 
 // Mount public API
 app.route("/api", publicApi);
+app.route("/api/obsidian/articles", obsidianSyncRoute);
 
 app.route("/", siteDocumentsRoute);
 


### PR DESCRIPTION
## Summary

Adds an authenticated `/api/obsidian/articles` API that lets an Obsidian
plugin push Markdown notes to the blog as TipTap articles, with optimistic
concurrency and conflict detection. Closes #（如果有 issue 就填）.

## Changes

- New `src/features/obsidian-sync/` module:
  - Hono route with constant-time Bearer token auth (`OBSIDIAN_SYNC_TOKEN`);
  - service layer for create / get / list / conditional update / delete;
  - Zod schemas for request validation;
  - D1 data layer for the `obsidian_post_links` link table.
- Migration `0011_obsidian_post_links.sql` (revision + content hash per post).
- `src/lib/hono/routes.ts` mounts the route at `/api/obsidian/articles`;
  responses use `Cache-Control: no-store` and are excluded from the cache middleware.
- Integration tests covering auth, CRUD, pagination and revision conflicts
  caused by website-side edits.

## How it works

- Content hash = SHA-256 of key-sorted `{ title, content }` (TipTap JSON),
  computed identically on both plugin and server sides.
- Updates carry `revision` + `contentHash`; a stale pair returns
  `409 REVISION_CONFLICT` with the current article instead of overwriting.
- `published: true` maps to `posts.status = "published"` and triggers the
  existing `startPostProcessWorkflow` (Shiki highlighting, public snapshot).

## Security

- The endpoint requires a secret Bearer token stored as the
  `OBSIDIAN_SYNC_TOKEN` Worker secret; it is never committed to the repo.
- The deployment workflow already uploads secrets via `wrangler secret bulk`
  (fork path reads it from repository secrets).

## Deployment notes

- Deploy runs `bun db:migrate` automatically, applying migration `0011`.
- The companion client is the Obsidian plugin "Blog Sync"
  (`obsidian-blog-sync`).

## Testing

- `bun run test` (integration tests use the Cloudflare vitest pool).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 Obsidian 文章同步 API，支持文章创建、读取、更新、删除及分页浏览。
  - 支持 Bearer Token 鉴权、版本冲突检测和强制更新。
  - 新增 Obsidian 同步令牌配置项。

- **Bug 修复**
  - Markdown 导出现在会正确转义特殊字符，避免文本被误解析为格式标记。

- **文档**
  - 补充 Obsidian 同步相关的环境变量说明、设计文档和实施计划。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->